### PR TITLE
Hotfix/packages fixes issue #3: buildPermissionsForUser() will always return an empty array for packages

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -352,8 +352,13 @@ class Auth
      */
     protected function buildPermissionsForUser(UserRepresentation $user)
     {
-        // Make use of Collection to do some clever sorting:
+
         $all_packages = $this->packagesForUser($user);
+        // initialize package objects
+        foreach($all_packages as $index => $package_name) {
+            $all_packages[$index] = new $package_name();
+        }
+        // Make use of Collection to do some clever sorting:
         $sorted_packages = new Collection($all_packages);
         $sorted_packages->sortByMember('precedence');
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -32,11 +32,14 @@ abstract class Package
     abstract public function init();
 
     /**
-     * Your package must return a name for itself.
+     * This returns the package's name
      *
      * @return    string
      */
-    abstract public function name();
+    public function name() {
+        // get the child's full name (namespace + class name)
+        return get_class($this);
+    }
 
     /**
      * Constructor calls init()

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -753,6 +753,28 @@ class AuthTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that precedence works how we expect it to
+     */
+    public function testPrecedenceApplied()
+    {
+        $storage_mock = new StorageDelegateMock();
+        $auth = new Auth('default', $this->session_mock, $storage_mock, array(
+            'cost' => 8,
+        ));
+
+        $user = $this->userMock(1);
+
+        // Add the packages out of order to ensure that they apply properly.
+        $auth->addPackageToUser($user, 'Solution10\Auth\Tests\Mocks\HigherPackage');
+        $auth->addPackageToUser($user, 'Solution10\Auth\Tests\Mocks\Package');
+
+        // HigherPackage login: true
+        // Package login: false
+        // Precedence dictates that HigherPackage should win out.
+        $this->assertTrue($auth->userCan($user, 'login'));
+    }
+
+    /**
      * Testing adding an override
      */
     public function testOverrideBasic()

--- a/tests/Mocks/Package.php
+++ b/tests/Mocks/Package.php
@@ -40,11 +40,6 @@ class Package extends BasePackage
 
     }
 
-    public function name()
-    {
-        return 'TestPackage';
-    }
-
     public function editPost()
     {
         return false;

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -94,6 +94,6 @@ class PackageTest extends PHPUnit_Framework_TestCase
     public function testName()
     {
         $package = new PackageMock();
-        $this->assertEquals('TestPackage', $package->name());
+        $this->assertEquals(PackageMock::class, $package->name());
     }
 }


### PR DESCRIPTION
This fixes #3 by using the class and it's namespace as name.